### PR TITLE
Move ghhooks to the dev dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "gh-pages": "^0.11.0",
-    "ghooks": "^1.3.2",
     "gulp": "^3.9.1",
     "gulp-notify": "^2.2.0",
     "gulp-plumber": "^1.1.0",
@@ -79,6 +78,9 @@
     "webpack-dev-middleware": "^1.6.1",
     "webpack-hot-middleware": "^2.12.2",
     "yargs": "^5.0.0"
+  },
+  "devDependencies": {
+    "ghooks": "^1.3.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It looks like Netlify installs these hooks in production and builds fail because the hooks don't have access to Node before the environment is set up for deploying. This is causing errors deploying the site.

I don't see a reason to have these hooks installed in production, so I moved the dependency to development. The push hook in the configuration should still run the linter.

Signed-off-by: David Calavera <david.calavera@gmail.com>